### PR TITLE
Add telegram and donation info

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,6 @@ Ein Alexa Skill, der darauf aufmerksam macht, wenn der Twitch-Kanal [digitalwelt
 Die Skill-Logik befindet sich in `digitalwelt_skill.py`. Zum Abfragen des Livestatus wird die Twitch-API genutzt. 
 
 Setze die Umgebungsvariablen `TWITCH_CLIENT_ID` und `TWITCH_ACCESS_TOKEN`, um den Skill auszuführen.
+
+Telegram: @Kodiman
+Spendenlink: https://ko-fi.com/kodimanhimself


### PR DESCRIPTION
## Summary
- add Telegram handle for Kodiman
- include Ko-fi donation link

## Testing
- `python -m py_compile digitalwelt_skill.py`

------
https://chatgpt.com/codex/tasks/task_e_687c99a30924833197b4f97d14ae4b09